### PR TITLE
test: add unit and e2e test coverage for problem judging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea
 submit
 run
-example
 .env
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,27 @@ go get -u ./...
 
 # 업데이트 후 go.mod/go.sum 정리 (사용하지 않는 의존성 제거, 필요한 것 추가)
 go mod tidy
+
+# 테스트 실행
+go test ./src/...
+
+# 테스트 실행 (테스트별 상세 결과 출력)
+go test -v ./src/...
+
+# 테스트 실행 (커버리지 % 표시)
+go test -cover ./src/...
+
+# E2E 테스트 실행 (실제 서버를 로컬에 띄우고 진짜 HTTP 요청으로 검증. 로컬에 언어별 컴파일러/런타임 + OCI 자격증명 필요)
+go test -tags=e2e ./test/...
 ```
 
-테스트 코드(`*_test.go`)는 현재 저장소에 존재하지 않는다.
+## 테스트 작성 규칙
+
+"어떤 함수에 어떤 입력을 넣으면 처리를 거쳐서 어떤 출력이 나와야 한다" 형식으로 유닛 테스트 작성을 요청하면, 그 스펙을 바로 Go 테스트 코드로 옮긴다. [src/language/language_test.go](src/language/language_test.go), [src/service/problem/service_test.go](src/service/problem/service_test.go)에 이미 있는 패턴을 따른다:
+- 테이블 드리븐 테스트(케이스를 구조체 슬라이스로 나열하고 `t.Run`으로 서브테스트 실행)
+- unexported 식별자(`allTrue`, `checkDifference` 등)를 테스트해야 하면 `package problem_test`가 아닌 `package problem`(내부 테스트)으로 작성
+
+"서버를 로컬에 띄우고 curl/API 호출로 어떤 요청을 하면 어떤 응답이 나와야 한다" 형식으로 e2e 테스트 작성을 요청하면 [test/e2e_test.go](test/e2e_test.go)의 패턴을 따라 E2E 테스트로 작성한다: `//go:build e2e` 빌드 태그로 일반 테스트와 분리하고, `route.RegisterRoutes`로 실제 서비스(진짜 Executor/파일저장소/OCI)를 그대로 띄운 뒤 `:0`으로 랜덤 포트를 확보(`OnListen` 훅으로 캡처)해 진짜 `net/http` 클라이언트로 요청한다. `submit` 엔드포인트는 OCI 버킷에 실제 문제 데이터가 있어야 검증 가능하므로, 요청 페이로드만으로 자기완결적인 `run` 엔드포인트 위주로 작성한다. 실행할 때마다 `run/{submitId}/` 디렉터리가 실제로 남고(응답에 submitId가 없어 자동 정리 불가) 이건 정상이니 놀라지 않는다.
 
 ## Architecture
 

--- a/src/language/language_test.go
+++ b/src/language/language_test.go
@@ -1,0 +1,47 @@
+package language
+
+import "testing"
+
+func TestFileExtension(t *testing.T) {
+	tests := []struct {
+		name     string
+		language string
+		want     string
+	}{
+		{"C", "C", "c"},
+		{"CPP", "CPP", "cpp"},
+		{"GO", "GO", "go"},
+		{"JAVA", "JAVA", "java"},
+		{"JAVASCRIPT", "JAVASCRIPT", "js"},
+		{"KOTLIN", "KOTLIN", "kt"},
+		{"PYTHON", "PYTHON", "py"},
+		{"SWIFT", "SWIFT", "swift"},
+		{"unknown language", "RUST", "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FileExtension(tt.language)
+			if got != tt.want {
+				t.Errorf("FileExtension(%q) = %q, want %q", tt.language, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReplaceCommand(t *testing.T) {
+	args := []string{"gcc", "{JUDGE_TYPE}/{SUBMIT_ID}/Main.c", "-o", "{JUDGE_TYPE}/{SUBMIT_ID}/Main"}
+
+	got := ReplaceCommand(args, "submit", 42)
+
+	want := []string{"gcc", "submit/42/Main.c", "-o", "submit/42/Main"}
+
+	if len(got) != len(want) {
+		t.Fatalf("ReplaceCommand() returned %d args, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ReplaceCommand()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/src/service/problem/service.go
+++ b/src/service/problem/service.go
@@ -66,12 +66,6 @@ func (service *Service) SubmitProblem(dto entity.SubmitProblemDTO) (entity.Judge
 		return entity.JudgeUnknown, 0, 0, err
 	}
 
-	result, err := service.exec.Build(buildCmd)
-	if err != nil {
-		log.Error(err)
-		return result, 0, 0, err
-	}
-
 	defer func() {
 		if err := service.exec.Delete(deleteCmd); err != nil {
 			log.Error(err)
@@ -85,6 +79,12 @@ func (service *Service) SubmitProblem(dto entity.SubmitProblemDTO) (entity.Judge
 			log.Error(err)
 		}
 	}()
+
+	result, err := service.exec.Build(buildCmd)
+	if err != nil {
+		log.Error(err)
+		return result, 0, 0, err
+	}
 
 	result, usedTime, usedMemory, err := service.judgeSubmit(runCmd, submitId, timeLimit, memoryLimit)
 	if err != nil {
@@ -125,17 +125,17 @@ func (service *Service) RunProblem(dto entity.RunProblemDTO) []entity.RunProblem
 		return []entity.RunProblemResult{{Result: entity.JudgeUnknown, Error: err}}
 	}
 
-	result, err := service.exec.Build(buildCmd)
-	if err != nil {
-		log.Error(err)
-		return []entity.RunProblemResult{{Result: result, Error: err}}
-	}
-
 	defer func() {
 		if err := service.exec.Delete(deleteCmd); err != nil {
 			log.Error(err)
 		}
 	}()
+
+	result, err := service.exec.Build(buildCmd)
+	if err != nil {
+		log.Error(err)
+		return []entity.RunProblemResult{{Result: result, Error: err}}
+	}
 
 	return service.judgeRun(runCmd, submitId, timeLimit, memoryLimit)
 }

--- a/src/service/problem/service_test.go
+++ b/src/service/problem/service_test.go
@@ -1,0 +1,325 @@
+package problem
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"leita/src/entity"
+)
+
+func b64(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+type runResult struct {
+	result     entity.JudgeResultEnum
+	output     []byte
+	usedTime   int64
+	usedMemory int64
+	err        error
+}
+
+type fakeExecutor struct {
+	buildResult entity.JudgeResultEnum
+	buildErr    error
+
+	runResults []runResult
+	runCalls   int
+
+	deleteErr   error
+	deleteCalls int
+}
+
+func (f *fakeExecutor) Build(buildCmd []string) (entity.JudgeResultEnum, error) {
+	return f.buildResult, f.buildErr
+}
+
+func (f *fakeExecutor) Run(runCmd []string, input []byte, timeLimit int) (entity.JudgeResultEnum, []byte, int64, int64, error) {
+	r := f.runResults[f.runCalls]
+	f.runCalls++
+	return r.result, r.output, r.usedTime, r.usedMemory, r.err
+}
+
+func (f *fakeExecutor) Delete(deleteCmd []string) error {
+	f.deleteCalls++
+	return f.deleteErr
+}
+
+type fakeFileRepo struct {
+	saveSourceCodeErr error
+	saveTestCasesErr  error
+
+	testCaseCount    int
+	testCaseCountErr error
+
+	inputs  [][]byte
+	outputs [][]byte
+}
+
+func (f *fakeFileRepo) SaveSourceCode(submitId int, code []byte, lang, judgeType string) error {
+	return f.saveSourceCodeErr
+}
+
+func (f *fakeFileRepo) SaveTestCases(submitId int, inputs, outputs [][]byte, judgeType string) error {
+	return f.saveTestCasesErr
+}
+
+func (f *fakeFileRepo) ReadInput(submitId int, index int, judgeType string) ([]byte, error) {
+	return f.inputs[index], nil
+}
+
+func (f *fakeFileRepo) ReadOutput(submitId int, index int, judgeType string) ([]byte, error) {
+	return f.outputs[index], nil
+}
+
+func (f *fakeFileRepo) GetTestCaseCount(submitId int, judgeType string) (int, error) {
+	return f.testCaseCount, f.testCaseCountErr
+}
+
+type fakeStorage struct {
+	objectsErr error
+
+	saveCodeErr   error
+	saveCodeCalls int
+}
+
+func (f *fakeStorage) SaveCode(path string, code []byte) error {
+	f.saveCodeCalls++
+	return f.saveCodeErr
+}
+
+func (f *fakeStorage) GetObjectsInFolder(path string) ([][]byte, error) {
+	return nil, f.objectsErr
+}
+
+func TestSubmitProblem(t *testing.T) {
+	tests := []struct {
+		name string
+
+		fileRepo *fakeFileRepo
+		exec     *fakeExecutor
+
+		wantResult        entity.JudgeResultEnum
+		wantErr           bool
+		wantUsedTime      int64
+		wantUsedMemory    int64
+		wantDeleteCalls   int
+		wantSaveCodeCalls int
+	}{
+		{
+			name: "정답: 모든 테스트케이스 일치",
+			fileRepo: &fakeFileRepo{
+				testCaseCount: 2,
+				inputs:        [][]byte{[]byte(b64("in0")), []byte(b64("in1"))},
+				outputs:       [][]byte{[]byte(b64("3")), []byte(b64("7"))},
+			},
+			exec: &fakeExecutor{
+				buildResult: entity.JudgeCorrect,
+				runResults: []runResult{
+					{result: entity.JudgeCorrect, output: []byte("3"), usedTime: 100, usedMemory: 1000},
+					{result: entity.JudgeCorrect, output: []byte("7"), usedTime: 300, usedMemory: 3000},
+				},
+			},
+			wantResult:        entity.JudgeCorrect,
+			wantUsedTime:      300, // 워밍업(첫 케이스 100ms) 제외 평균
+			wantUsedMemory:    2000,
+			wantDeleteCalls:   1,
+			wantSaveCodeCalls: 1,
+		},
+		{
+			name: "오답: 워밍업 케이스만 불일치해도 전체 결과는 WRONG",
+			fileRepo: &fakeFileRepo{
+				testCaseCount: 2,
+				inputs:        [][]byte{[]byte(b64("in0")), []byte(b64("in1"))},
+				outputs:       [][]byte{[]byte(b64("3")), []byte(b64("7"))},
+			},
+			exec: &fakeExecutor{
+				buildResult: entity.JudgeCorrect,
+				runResults: []runResult{
+					{result: entity.JudgeCorrect, output: []byte("WRONG"), usedTime: 100, usedMemory: 1000},
+					{result: entity.JudgeCorrect, output: []byte("7"), usedTime: 300, usedMemory: 3000},
+				},
+			},
+			wantResult:        entity.JudgeWrong,
+			wantUsedTime:      300,
+			wantUsedMemory:    2000,
+			wantDeleteCalls:   1,
+			wantSaveCodeCalls: 1,
+		},
+		{
+			name:     "Build 실패: Delete/SaveCode는 그래도 호출된다",
+			fileRepo: &fakeFileRepo{},
+			exec: &fakeExecutor{
+				buildResult: entity.JudgeCompileError,
+				buildErr:    errors.New("compile error"),
+			},
+			wantResult:        entity.JudgeCompileError,
+			wantErr:           true,
+			wantDeleteCalls:   1,
+			wantSaveCodeCalls: 1,
+		},
+		{
+			name: "Run 실패(타임아웃)",
+			fileRepo: &fakeFileRepo{
+				testCaseCount: 1,
+				inputs:        [][]byte{[]byte(b64("in0"))},
+				outputs:       [][]byte{[]byte(b64("3"))},
+			},
+			exec: &fakeExecutor{
+				buildResult: entity.JudgeCorrect,
+				runResults: []runResult{
+					{result: entity.JudgeTimeOut, err: errors.New("timeout")},
+				},
+			},
+			wantResult:        entity.JudgeTimeOut,
+			wantErr:           true,
+			wantDeleteCalls:   1,
+			wantSaveCodeCalls: 1,
+		},
+		{
+			name:     "테스트케이스 0개",
+			fileRepo: &fakeFileRepo{testCaseCount: 0},
+			exec: &fakeExecutor{
+				buildResult: entity.JudgeCorrect,
+			},
+			wantResult:        entity.JudgeUnknown,
+			wantErr:           true,
+			wantDeleteCalls:   1,
+			wantSaveCodeCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := &fakeStorage{}
+			service := NewService(storage, tt.fileRepo, tt.exec)
+
+			result, usedTime, usedMemory, err := service.SubmitProblem(entity.SubmitProblemDTO{
+				ProblemId: "1",
+				SubmitId:  1,
+				Language:  "PYTHON",
+				Code:      []byte("print(42)"),
+				Limit:     entity.Limit{Time: 1000, Memory: 65536},
+			})
+
+			if result != tt.wantResult {
+				t.Errorf("result = %v, want %v", result, tt.wantResult)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if usedTime != tt.wantUsedTime {
+				t.Errorf("usedTime = %d, want %d", usedTime, tt.wantUsedTime)
+			}
+			if usedMemory != tt.wantUsedMemory {
+				t.Errorf("usedMemory = %d, want %d", usedMemory, tt.wantUsedMemory)
+			}
+			if tt.exec.deleteCalls != tt.wantDeleteCalls {
+				t.Errorf("Delete calls = %d, want %d", tt.exec.deleteCalls, tt.wantDeleteCalls)
+			}
+			if storage.saveCodeCalls != tt.wantSaveCodeCalls {
+				t.Errorf("SaveCode calls = %d, want %d", storage.saveCodeCalls, tt.wantSaveCodeCalls)
+			}
+		})
+	}
+}
+
+func TestRunProblem(t *testing.T) {
+	tests := []struct {
+		name string
+
+		testCases []entity.TestCase
+		fileRepo  *fakeFileRepo
+		exec      *fakeExecutor
+
+		wantResults     []entity.RunProblemResult
+		wantErr         bool
+		wantDeleteCalls int
+	}{
+		{
+			name: "정답/오답 혼합",
+			testCases: []entity.TestCase{
+				{Input: b64("in0"), Output: b64("3")},
+				{Input: b64("in1"), Output: b64("7")},
+			},
+			fileRepo: &fakeFileRepo{
+				testCaseCount: 2,
+				inputs:        [][]byte{[]byte(b64("in0")), []byte(b64("in1"))},
+				outputs:       [][]byte{[]byte(b64("3")), []byte(b64("7"))},
+			},
+			exec: &fakeExecutor{
+				buildResult: entity.JudgeCorrect,
+				runResults: []runResult{
+					{result: entity.JudgeCorrect, output: []byte("3")},
+					{result: entity.JudgeCorrect, output: []byte("WRONG")},
+				},
+			},
+			wantResults: []entity.RunProblemResult{
+				{Result: entity.JudgeCorrect, Output: b64("3")},
+				{Result: entity.JudgeWrong, Output: b64("WRONG")},
+			},
+			wantDeleteCalls: 1,
+		},
+		{
+			name:      "Build 실패: Delete는 그래도 호출된다",
+			testCases: []entity.TestCase{{Input: b64("in0"), Output: b64("3")}},
+			fileRepo:  &fakeFileRepo{},
+			exec: &fakeExecutor{
+				buildResult: entity.JudgeCompileError,
+				buildErr:    errors.New("compile error"),
+			},
+			wantResults: []entity.RunProblemResult{
+				{Result: entity.JudgeCompileError},
+			},
+			wantErr:         true,
+			wantDeleteCalls: 1,
+		},
+		{
+			name:      "테스트케이스 저장 실패: Delete는 호출되지 않는다",
+			testCases: []entity.TestCase{{Input: b64("in0"), Output: b64("3")}},
+			fileRepo: &fakeFileRepo{
+				saveTestCasesErr: errors.New("disk full"),
+			},
+			exec: &fakeExecutor{},
+			wantResults: []entity.RunProblemResult{
+				{Result: entity.JudgeUnknown},
+			},
+			wantErr:         true,
+			wantDeleteCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewService(&fakeStorage{}, tt.fileRepo, tt.exec)
+
+			results := service.RunProblem(entity.RunProblemDTO{
+				ProblemId: "1",
+				Language:  "PYTHON",
+				Code:      []byte("print(42)"),
+				Limit:     entity.Limit{Time: 1000, Memory: 65536},
+				TestCases: tt.testCases,
+			})
+
+			if len(results) != len(tt.wantResults) {
+				t.Fatalf("len(results) = %d, want %d", len(results), len(tt.wantResults))
+			}
+			for i, want := range tt.wantResults {
+				got := results[i]
+				if got.Result != want.Result {
+					t.Errorf("results[%d].Result = %v, want %v", i, got.Result, want.Result)
+				}
+				if got.Output != want.Output {
+					t.Errorf("results[%d].Output = %q, want %q", i, got.Output, want.Output)
+				}
+				if (got.Error != nil) != tt.wantErr {
+					t.Errorf("results[%d].Error = %v, wantErr %v", i, got.Error, tt.wantErr)
+				}
+			}
+			if tt.exec.deleteCalls != tt.wantDeleteCalls {
+				t.Errorf("Delete calls = %d, want %d", tt.exec.deleteCalls, tt.wantDeleteCalls)
+			}
+		})
+	}
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1,0 +1,123 @@
+//go:build e2e
+
+package test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"leita/src/entity"
+	"leita/src/route"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/joho/godotenv"
+)
+
+func startTestServer(t *testing.T) string {
+	t.Helper()
+
+	_ = godotenv.Load(".env")
+
+	app := fiber.New()
+	if err := route.RegisterRoutes(app); err != nil {
+		t.Fatalf("라우트 등록 실패: %v", err)
+	}
+
+	portCh := make(chan string, 1)
+	app.Hooks().OnListen(func(ld fiber.ListenData) error {
+		portCh <- ld.Port
+		return nil
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Listen(":0", fiber.ListenConfig{DisableStartupMessage: true})
+	}()
+
+	var port string
+	select {
+	case port = <-portCh:
+	case err := <-errCh:
+		t.Fatalf("서버 기동 실패: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("서버가 5초 내에 기동되지 않았다")
+	}
+
+	t.Cleanup(func() {
+		if err := app.ShutdownWithTimeout(5 * time.Second); err != nil {
+			t.Errorf("서버 종료 실패: %v", err)
+		}
+	})
+
+	return "http://127.0.0.1:" + port
+}
+
+func TestRunProblemE2E(t *testing.T) {
+	baseURL := startTestServer(t)
+
+	code := "n = int(input())\nprint(n * 2)\n"
+	reqBody := entity.RunProblemRequest{
+		Language: "PYTHON",
+		Code:     base64.StdEncoding.EncodeToString([]byte(code)),
+		Limit:    entity.Limit{Time: 3000, Memory: 65536},
+		TestCases: []entity.TestCase{
+			{
+				Input:  base64.StdEncoding.EncodeToString([]byte("3")),
+				Output: base64.StdEncoding.EncodeToString([]byte("6")),
+			},
+			{
+				Input:  base64.StdEncoding.EncodeToString([]byte("5")),
+				Output: base64.StdEncoding.EncodeToString([]byte("10")),
+			},
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("요청 payload 직렬화 실패: %v", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Post(baseURL+"/api/problem/run/1", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("요청 실패: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("응답 바디 읽기 실패: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d\nbody: %s", resp.StatusCode, http.StatusOK, respBody)
+	}
+
+	var results []entity.RunProblemResponse
+	if err := json.Unmarshal(respBody, &results); err != nil {
+		t.Fatalf("응답 JSON 파싱 실패: %v\nbody: %s", err, respBody)
+	}
+
+	if len(results) != len(reqBody.TestCases) {
+		t.Fatalf("len(results) = %d, want %d", len(results), len(reqBody.TestCases))
+	}
+
+	wantOutputs := []string{
+		base64.StdEncoding.EncodeToString([]byte("6")),
+		base64.StdEncoding.EncodeToString([]byte("10")),
+	}
+
+	for i, result := range results {
+		if result.Result != entity.JudgeCorrect.String() {
+			t.Errorf("results[%d].Result = %q, want %q (error: %s)", i, result.Result, entity.JudgeCorrect.String(), result.Error)
+		}
+		if result.Output != wantOutputs[i] {
+			t.Errorf("results[%d].Output = %q, want %q", i, result.Output, wantOutputs[i])
+		}
+	}
+}


### PR DESCRIPTION
Add table-driven unit tests for src/language and src/service/problem, using hand-rolled fakes for the Executor/Repository/storage interfaces instead of a mocking framework. Add an e2e test (test/e2e_test.go, built with the "e2e" tag) that boots the real server on a random port and drives the run endpoint over HTTP with a real interpreter.

While writing the SubmitProblem/RunProblem unit tests, fix an inconsistency where a Build failure skipped the Delete and SaveCode defers that a later Run failure would still trigger; both now always run once the source code has been saved, regardless of Build outcome.

Document the go test / go test -tags=e2e commands and the test-writing conventions in CLAUDE.md, and ignore the local "leita" build artifact in .gitignore.