### PR TITLE
feat: measure memory usage with cgroup v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,15 @@ go test -v ./src/...
 # 테스트 실행 (커버리지 % 표시)
 go test -cover ./src/...
 
+# 유닛 테스트를 Linux(운영과 동일 커널 인터페이스)에서 실행. --privileged를 주면
+# 실제 cgroup을 쓰는 통합 테스트(src/executor/integration_linux_test.go)까지 돌고,
+# 없으면 통합 테스트는 자동 skip된다.
+docker run --rm --privileged -v "$PWD":/workspace -v "$(go env GOMODCACHE)":/go/pkg/mod \
+  -w /workspace golang:1.26.2-alpine3.23 go test ./src/...
+
+# 운영(k8s host cgroupns) 경로를 로컬에서 재현하려면 서버를 이렇게 띄운다
+# docker run --privileged --cgroupns=host <run 스테이지 이미지> ...
+
 # E2E 테스트 실행 (실제 서버를 로컬에 띄우고 진짜 HTTP 요청으로 검증. 로컬에 언어별 컴파일러/런타임 + OCI 자격증명 필요)
 go test -tags=e2e ./test/...
 ```
@@ -45,6 +54,7 @@ go test -tags=e2e ./test/...
 "어떤 함수에 어떤 입력을 넣으면 처리를 거쳐서 어떤 출력이 나와야 한다" 형식으로 유닛 테스트 작성을 요청하면, 그 스펙을 바로 Go 테스트 코드로 옮긴다. [src/language/language_test.go](src/language/language_test.go), [src/service/problem/service_test.go](src/service/problem/service_test.go)에 이미 있는 패턴을 따른다:
 - 테이블 드리븐 테스트(케이스를 구조체 슬라이스로 나열하고 `t.Run`으로 서브테스트 실행)
 - unexported 식별자(`allTrue`, `checkDifference` 등)를 테스트해야 하면 `package problem_test`가 아닌 `package problem`(내부 테스트)으로 작성
+- 채점 로직 테스트에서 문제의 테스트케이스 픽스처는 **최소 5개**로 구성한다 (실제 문제가 최소 5개 테스트케이스를 보장하는 정책과 일치시키기 위함)
 
 "서버를 로컬에 띄우고 curl/API 호출로 어떤 요청을 하면 어떤 응답이 나와야 한다" 형식으로 e2e 테스트 작성을 요청하면 [test/e2e_test.go](test/e2e_test.go)의 패턴을 따라 E2E 테스트로 작성한다: `//go:build e2e` 빌드 태그로 일반 테스트와 분리하고, `route.RegisterRoutes`로 실제 서비스(진짜 Executor/파일저장소/OCI)를 그대로 띄운 뒤 `:0`으로 랜덤 포트를 확보(`OnListen` 훅으로 캡처)해 진짜 `net/http` 클라이언트로 요청한다. `submit` 엔드포인트는 OCI 버킷에 실제 문제 데이터가 있어야 검증 가능하므로, 요청 페이로드만으로 자기완결적인 `run` 엔드포인트 위주로 작성한다. 실행할 때마다 `run/{submitId}/` 디렉터리가 실제로 남고(응답에 submitId가 없어 자동 정리 불가) 이건 정상이니 놀라지 않는다.
 
@@ -63,16 +73,17 @@ main.go
 
 - **entity** ([src/entity/problem.go](src/entity/problem.go)) — 요청/응답 DTO와 `JudgeResultEnum`(CORRECT/WRONG/COMPILE_ERROR/RUNTIME_ERROR/MEMORY_OUT/TIME_OUT) 등 도메인 타입 전체가 여기 모여 있다.
 - **language** ([src/language/language.go](src/language/language.go)) — 언어별 빌드/실행/삭제 커맨드를 `{JUDGE_TYPE}`/`{SUBMIT_ID}` 플레이스홀더가 있는 템플릿으로 정의(`Commands` 맵). `ReplaceCommand`로 실제 경로를 채워 넣는다. 소스 파일명은 항상 `Main.{ext}`(`FileName` 상수)로 고정된다.
-- **executor** ([src/executor/executor.go](src/executor/executor.go)) — `Executor` 인터페이스(Build/Run/Delete)의 실제 구현인 `OsExecutor`가 `os/exec`로 컴파일러/런타임 프로세스를 직접 구동한다. `Run`은 `context.WithTimeout`으로 제한 시간을 강제하며 타임아웃은 `JudgeTimeOut`, 비정상 종료는 `JudgeRuntimeError`로 매핑된다.
+- **cgroup** ([src/cgroup/cgroup.go](src/cgroup/cgroup.go)) — cgroup v2 기반 메모리 측정 계층. 테스트케이스 실행마다 `/sys/fs/cgroup/leita-judge/{pod}/{seq}`에 일회용 cgroup을 만들고, 채점 프로세스를 clone3(`CLONE_INTO_CGROUP`)로 그 안에서 시작시킨 뒤 종료 후 `memory.peak`을 읽는다(KB 단위). `{pod}`는 `os.Hostname()`(k8s 파드명/Docker 컨테이너 ID)으로, 같은 노드의 여러 judge 파드 간 격리 계층이다. `Setup()`이 시작 시 환경을 감지한다: `/proc/self/cgroup`이 `0::/`이면(로컬 Docker, private cgroupns) 루트 프로세스를 `main/` leaf로 옮겨 "no internal processes" 규칙을 회피하고, 아니면(k8s privileged + host cgroupns) 파드 계층만 만든다. 시작 시 자기 파드의 잔존 세션만 정리하며 다른 파드 디렉터리는 절대 건드리지 않는다. cgroup을 쓸 수 없으면(비-privileged 컨테이너, macOS) 경고 로그 후 측정값 0을 반환하는 폴백으로 기동한다. **측정 범위는 코드 실행(stdin~stdout)만이며 Build/Delete는 cgroup 밖에서 실행되어 절대 포함되지 않는다.**
+- **executor** ([src/executor/executor.go](src/executor/executor.go)) — `Executor` 인터페이스(Build/Run/Delete)의 실제 구현인 `OsExecutor`가 `os/exec`로 컴파일러/런타임 프로세스를 직접 구동한다. `Run`은 `context.WithTimeout`으로 제한 시간을 강제하고, cgroup 세션으로 메모리를 측정하며 `memoryLimit`에 안전망 상한(문제 제한 + 1GiB)을 건다(정식 제한과 언어별 마진은 후속 작업). 판정 우선순위는 **OOM(`JudgeMemoryOut`) → 타임아웃(`JudgeTimeOut`) → 비정상 종료(`JudgeRuntimeError`)** 순서다 — OOM kill은 SIGKILL이라 순서를 바꾸면 메모리 초과가 RUNTIME_ERROR나 TIME_OUT으로 오분류된다.
 - **repository/file** ([src/repository/file/repository.go](src/repository/file/repository.go)) — 로컬 파일시스템에 소스 코드/테스트케이스를 저장하는 `Repository` 인터페이스(`LocalRepository` 구현). 경로 규칙은 `{judgeType}/{submitId}/Main.{ext}`, `{judgeType}/{submitId}/in/{i}.in`, `{judgeType}/{submitId}/out/{i}.out`.
-- **repository/problem** + **datasource** ([src/datasource/objectstorage.go](src/datasource/objectstorage.go)) — OCI Object Storage를 감싸는 계층. 문제의 정답 테스트케이스를 `problems/{problemId}/testcases`에서 읽어오고, 제출된 코드를 `submits/{submitId}/...`에 base64로 저장한다.
+- **repository/problem** + **datasource** ([src/datasource/objectstorage.go](src/datasource/objectstorage.go)) — OCI Object Storage를 감싸는 계층. 문제의 정답 테스트케이스를 `problems/{problemId}/testcases`에서 읽어오고, 제출된 코드를 `submits/{submitId}/...`에 base64로 저장한다. **정책: 모든 문제는 최소 5개의 테스트케이스를 보장한다** — 문제 퀄리티를 위한 정책으로 문제 데이터 등록 단계에서 강제되며, 이 레포 코드에는 별도 검증 로직이 없다.
 - **service/problem** ([src/service/problem/service.go](src/service/problem/service.go)) — 채점 핵심 로직. 저장 → 빌드 → (테스트케이스별) 실행 → 출력 바이트 비교(`bytes.Equal`) → 결과 집계 순으로 진행하고, 빌드/삭제 실패 시에도 실행 파일 삭제(`Delete`)가 `defer`로 항상 시도된다.
 
 ### Judge 타입: `submit` vs `run`
 
 같은 `Service`가 두 가지 판정 흐름을 처리하며, `judgeType` 문자열("submit"/"run")로 파일 경로와 동작이 갈린다.
 
-- **submit** (`SubmitProblem`) — `submitId`는 요청에서 받은 실제 제출 ID. 테스트케이스는 OCI Object Storage의 문제 데이터에서 가져오고, 채점 후 제출 코드를 Object Storage에 base64로 영구 저장한다. 평균 사용 시간은 첫 번째 테스트케이스(워밍업으로 간주)를 제외하고 계산한다(`judgeSubmit`).
+- **submit** (`SubmitProblem`) — `submitId`는 요청에서 받은 실제 제출 ID. 테스트케이스는 OCI Object Storage의 문제 데이터에서 가져오고, 채점 후 제출 코드를 Object Storage에 base64로 영구 저장한다. 평균 사용 시간·사용 메모리는 첫 번째 테스트케이스(워밍업으로 간주 — 시간은 JIT/캐시 예열, 메모리는 페이지 캐시 첫 적재 비용)를 제외하고 계산한다(`judgeSubmit`의 `averageExcludingWarmup`).
 - **run** (`RunProblem`) — 코드 테스트/실행 목적. `submitId`는 매 요청마다 12자리 난수로 생성하고, 테스트케이스는 요청 바디에 실려온 것을 그대로 사용한다. Object Storage에 결과를 저장하지 않고, 각 테스트케이스의 실제 출력(base64)까지 응답에 포함한다.
 
 두 경우 모두 로컬 디렉터리 `submit/{id}/`, `run/{id}/`가 작업 공간으로 쓰이며(`.gitignore`에 포함되어 커밋되지 않음), 채점 완료 후 빌드 산출물만 `Delete` 커맨드로 정리되고 소스/입출력 파일은 남는다.
@@ -80,6 +91,8 @@ main.go
 ### 배포 구조
 
 `deploy/Dockerfile-{language}`가 언어별로 하나씩 존재한다. 모든 이미지가 동일한 Go 서버 바이너리를 빌드하지만, 최종 런타임 스테이지 베이스 이미지만 언어별 컴파일러/런타임(gcc, jdk, node, python 등)으로 다르게 지정된다 — 즉 언어별로 별도 컨테이너를 띄워 해당 언어의 코드만 처리하는 구조. Swift는 현재 Dockerfile 전체가 주석 처리되어 비활성화 상태다.
+
+메모리 측정은 컨테이너 안에서 `/sys/fs/cgroup`이 rw여야 동작한다. k8s에서는 judge Deployment에 `securityContext.privileged: true`가 필요하며(GitOps 레포에서 관리), 없으면 서버는 정상 동작하되 `usedMemory`가 항상 0이다(폴백 모드). 노드 요구사항: cgroup v2 + 커널 5.19+(`memory.peak`).
 
 ### API
 

--- a/src/cgroup/cgroup.go
+++ b/src/cgroup/cgroup.go
@@ -159,10 +159,24 @@ func cleanupLeftovers(podDir string) {
 		}
 		dir := filepath.Join(podDir, entry.Name())
 		killCgroup(dir)
-		if err := os.Remove(dir); err != nil {
+		if err := removeDirWithRetry(dir); err != nil {
 			log.Warn("잔존 cgroup 정리 실패: ", err)
 		}
 	}
+}
+
+// removeDirWithRetry는 cgroup 디렉터리를 재시도하며 삭제한다. cgroup.kill의
+// 프로세스 종료가 비동기라 직후의 rmdir은 EBUSY로 실패할 수 있다.
+func removeDirWithRetry(dir string) error {
+	var err error
+	for i := 0; i < 5; i++ {
+		err = os.Remove(dir)
+		if err == nil || errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return err
 }
 
 // killCgroup은 cgroup.kill이 존재하면(실제 cgroupfs) 하위 프로세스를 일괄 종료한다.
@@ -229,19 +243,8 @@ func (s *fsSession) OOMKilled() (bool, error) {
 func (s *fsSession) Close() error {
 	killCgroup(s.dir)
 	closeErr := s.fd.Close()
-
-	var removeErr error
-	for i := 0; i < 5; i++ {
-		removeErr = os.Remove(s.dir)
-		if removeErr == nil || errors.Is(removeErr, os.ErrNotExist) {
-			removeErr = nil
-			break
-		}
-		// 프로세스 종료 직후에는 커널 정리가 끝나지 않아 EBUSY가 날 수 있다.
-		time.Sleep(10 * time.Millisecond)
-	}
-	if removeErr != nil {
-		return fmt.Errorf("세션 cgroup 삭제 실패: %w", removeErr)
+	if err := removeDirWithRetry(s.dir); err != nil {
+		return fmt.Errorf("세션 cgroup 삭제 실패: %w", err)
 	}
 	return closeErr
 }

--- a/src/cgroup/cgroup.go
+++ b/src/cgroup/cgroup.go
@@ -1,0 +1,304 @@
+package cgroup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v3/log"
+)
+
+const (
+	// DefaultRoot는 cgroup v2 파일시스템의 마운트 지점이다.
+	DefaultRoot = "/sys/fs/cgroup"
+
+	// baseDirName 아래에 파드별 격리 계층({pod})이 생기고, 그 아래에 세션 cgroup이 생긴다.
+	// 최종 경로: {root}/leita-judge/{pod}/{session}
+	baseDirName = "leita-judge"
+
+	// leafName은 로컬 Docker(private cgroupns)에서 "no internal processes" 규칙을
+	// 피하기 위해 서버 프로세스를 옮겨 둘 leaf cgroup 이름이다.
+	leafName = "main"
+
+	// safetyMarginBytes는 측정 전용 1차 구현의 안전망이다. 채점용 제한(MEMORY_OUT
+	// 판정 기준)은 언어별 마진 정책 결정 후 후속 PR에서 적용하고, 여기서는 폭주한
+	// 프로세스가 노드 메모리를 다 먹지 않도록 문제 제한 + 1GiB 상한만 건다.
+	safetyMarginBytes = int64(1) << 30
+)
+
+// Monitor는 채점 프로세스 1회 실행에 대한 메모리 측정 세션을 발급한다.
+type Monitor interface {
+	NewSession(name string, memoryLimitKB int) (Session, error)
+}
+
+// Session은 실행 1회를 감싸는 일회용 cgroup이다. cmd 시작 전에 Apply를 호출하고,
+// 종료 후 PeakMemoryKB/OOMKilled를 읽은 뒤 Close로 정리한다.
+type Session interface {
+	Apply(cmd *exec.Cmd) error
+	PeakMemoryKB() (int64, error)
+	OOMKilled() (bool, error)
+	Close() error
+}
+
+// Setup은 cgroup 환경을 감지하고 측정 준비를 한다. 실패하면 측정하지 않는
+// 폴백 Monitor와 원인 에러를 함께 반환하므로 서버는 항상 기동할 수 있다.
+func Setup() (Monitor, error) {
+	return SetupAt(DefaultRoot)
+}
+
+// SetupAt은 테스트에서 가짜 cgroupfs 루트를 주입할 수 있도록 분리된 Setup 본체다.
+func SetupAt(root string) (Monitor, error) {
+	controllers, err := os.ReadFile(filepath.Join(root, "cgroup.controllers"))
+	if err != nil {
+		return NewFallbackMonitor(), fmt.Errorf("cgroup v2를 사용할 수 없습니다: %w", err)
+	}
+	if !hasController(string(controllers), "memory") {
+		return NewFallbackMonitor(), errors.New("cgroup memory 컨트롤러를 사용할 수 없습니다")
+	}
+
+	if err := escapeRootIfNeeded(root); err != nil {
+		return NewFallbackMonitor(), err
+	}
+
+	pod, err := os.Hostname()
+	if err != nil {
+		return NewFallbackMonitor(), fmt.Errorf("파드 식별자(hostname)를 얻을 수 없습니다: %w", err)
+	}
+
+	base := filepath.Join(root, baseDirName)
+	podDir := filepath.Join(base, pod)
+	for _, dir := range []string{base, podDir} {
+		if err := os.Mkdir(dir, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+			return NewFallbackMonitor(), fmt.Errorf("cgroup 생성 실패 (%s): %w", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "cgroup.subtree_control"), []byte("+memory"), 0o644); err != nil {
+			return NewFallbackMonitor(), fmt.Errorf("memory 컨트롤러 위임 실패 (%s): %w", dir, err)
+		}
+	}
+
+	cleanupLeftovers(podDir)
+
+	return &fsMonitor{dir: podDir}, nil
+}
+
+// readSelfCgroup은 테스트에서 /proc/self/cgroup 내용을 주입할 수 있도록 변수다.
+var readSelfCgroup = func() ([]byte, error) {
+	return os.ReadFile("/proc/self/cgroup")
+}
+
+// inRootCgroup은 서버 프로세스가 (현재 cgroup 네임스페이스 기준) 루트 cgroup에
+// 있는지 판별한다. 루트 cgroup.procs의 PID 목록과 비교하는 방식은 host cgroupns
+// 에서 PID 네임스페이스가 달라 오탐할 수 있으므로 /proc/self/cgroup을 쓴다.
+func inRootCgroup() (bool, error) {
+	data, err := readSelfCgroup()
+	if err != nil {
+		return false, fmt.Errorf("/proc/self/cgroup을 읽을 수 없습니다: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if path, ok := strings.CutPrefix(line, "0::"); ok {
+			return strings.TrimSpace(path) == "/", nil
+		}
+	}
+	return false, errors.New("cgroup v2 항목(0::)을 찾을 수 없습니다")
+}
+
+// escapeRootIfNeeded는 로컬 Docker(private cgroupns)처럼 서버 프로세스가 루트
+// cgroup에 있는 경우에만 "no internal processes" 규칙을 피하기 위해 루트의 모든
+// 프로세스를 leaf로 옮기고 루트에 memory 컨트롤러를 위임한다. k8s(privileged,
+// host cgroupns)에서는 서버가 kubepods 계층 안에 있고 루트는 systemd가 이미
+// 위임해 두었으므로 아무것도 하지 않는다.
+func escapeRootIfNeeded(root string) error {
+	inRoot, err := inRootCgroup()
+	if err != nil {
+		return err
+	}
+	if !inRoot {
+		return nil
+	}
+
+	leaf := filepath.Join(root, leafName)
+	if err := os.Mkdir(leaf, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+		return fmt.Errorf("leaf cgroup 생성 실패: %w", err)
+	}
+
+	procs, err := os.ReadFile(filepath.Join(root, "cgroup.procs"))
+	if err != nil {
+		return fmt.Errorf("루트 cgroup.procs를 읽을 수 없습니다: %w", err)
+	}
+	for _, pid := range strings.Fields(string(procs)) {
+		// 이미 종료된 프로세스는 실패해도 무방하다.
+		_ = os.WriteFile(filepath.Join(leaf, "cgroup.procs"), []byte(pid), 0o644)
+	}
+	// 자기 자신은 반드시 옮겨져야 한다 (누락 시 subtree_control 위임이 실패한다).
+	if err := os.WriteFile(filepath.Join(leaf, "cgroup.procs"), []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
+		return fmt.Errorf("서버 프로세스를 leaf cgroup으로 옮기지 못했습니다: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "cgroup.subtree_control"), []byte("+memory"), 0o644); err != nil {
+		return fmt.Errorf("루트 memory 컨트롤러 위임 실패: %w", err)
+	}
+	return nil
+}
+
+// cleanupLeftovers는 같은 파드(hostname 동일)의 이전 컨테이너가 남긴 세션
+// 디렉터리만 정리한다. 다른 파드의 디렉터리는 같은 노드에서 채점 중인 세션일 수
+// 있으므로 절대 건드리지 않는다.
+func cleanupLeftovers(podDir string) {
+	entries, err := os.ReadDir(podDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := filepath.Join(podDir, entry.Name())
+		killCgroup(dir)
+		if err := os.Remove(dir); err != nil {
+			log.Warn("잔존 cgroup 정리 실패: ", err)
+		}
+	}
+}
+
+// killCgroup은 cgroup.kill이 존재하면(실제 cgroupfs) 하위 프로세스를 일괄 종료한다.
+func killCgroup(dir string) {
+	kill := filepath.Join(dir, "cgroup.kill")
+	if _, err := os.Stat(kill); err != nil {
+		return
+	}
+	if err := os.WriteFile(kill, []byte("1"), 0o644); err != nil {
+		log.Warn("cgroup.kill 실패: ", err)
+	}
+}
+
+type fsMonitor struct {
+	dir string
+}
+
+func (m *fsMonitor) NewSession(name string, memoryLimitKB int) (Session, error) {
+	dir := filepath.Join(m.dir, name)
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("세션 cgroup 생성 실패: %w", err)
+	}
+
+	if memoryLimitKB > 0 {
+		limit := int64(memoryLimitKB)*1024 + safetyMarginBytes
+		if err := os.WriteFile(filepath.Join(dir, "memory.max"), []byte(strconv.FormatInt(limit, 10)), 0o644); err != nil {
+			log.Warn("memory.max 설정 실패 (측정은 계속 진행): ", err)
+		}
+		// 스왑으로 메모리 상한이 무력화되지 않도록 막는다.
+		if err := os.WriteFile(filepath.Join(dir, "memory.swap.max"), []byte("0"), 0o644); err != nil {
+			log.Warn("memory.swap.max 설정 실패 (측정은 계속 진행): ", err)
+		}
+	}
+
+	fd, err := os.Open(dir)
+	if err != nil {
+		_ = os.Remove(dir)
+		return nil, fmt.Errorf("세션 cgroup 열기 실패: %w", err)
+	}
+	return &fsSession{dir: dir, fd: fd}, nil
+}
+
+type fsSession struct {
+	dir string
+	fd  *os.File
+}
+
+func (s *fsSession) PeakMemoryKB() (int64, error) {
+	data, err := os.ReadFile(filepath.Join(s.dir, "memory.peak"))
+	if err != nil {
+		return 0, fmt.Errorf("memory.peak 읽기 실패: %w", err)
+	}
+	return parsePeakKB(data)
+}
+
+func (s *fsSession) OOMKilled() (bool, error) {
+	data, err := os.ReadFile(filepath.Join(s.dir, "memory.events"))
+	if err != nil {
+		return false, fmt.Errorf("memory.events 읽기 실패: %w", err)
+	}
+	return parseOOMKilled(data)
+}
+
+func (s *fsSession) Close() error {
+	killCgroup(s.dir)
+	closeErr := s.fd.Close()
+
+	var removeErr error
+	for i := 0; i < 5; i++ {
+		removeErr = os.Remove(s.dir)
+		if removeErr == nil || errors.Is(removeErr, os.ErrNotExist) {
+			removeErr = nil
+			break
+		}
+		// 프로세스 종료 직후에는 커널 정리가 끝나지 않아 EBUSY가 날 수 있다.
+		time.Sleep(10 * time.Millisecond)
+	}
+	if removeErr != nil {
+		return fmt.Errorf("세션 cgroup 삭제 실패: %w", removeErr)
+	}
+	return closeErr
+}
+
+func parsePeakKB(data []byte) (int64, error) {
+	n, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("memory.peak 파싱 실패: %w", err)
+	}
+	return n / 1024, nil
+}
+
+func parseOOMKilled(data []byte) (bool, error) {
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || fields[0] != "oom_kill" {
+			continue
+		}
+		n, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			return false, fmt.Errorf("memory.events 파싱 실패: %w", err)
+		}
+		return n > 0, nil
+	}
+	return false, nil
+}
+
+func hasController(controllers, name string) bool {
+	for _, c := range strings.Fields(controllers) {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+
+// NewFallbackMonitor는 cgroup을 쓸 수 없는 환경(macOS 컴파일 호환, cgroup 미지원
+// 컨테이너)에서 측정 없이(0 반환) 동작하는 Monitor를 반환한다.
+func NewFallbackMonitor() Monitor {
+	return fallbackMonitor{}
+}
+
+// NewFallbackSession은 세션 생성에 실패했을 때 실행 흐름을 유지하기 위한
+// no-op 세션을 반환한다.
+func NewFallbackSession() Session {
+	return fallbackSession{}
+}
+
+type fallbackMonitor struct{}
+
+func (fallbackMonitor) NewSession(string, int) (Session, error) {
+	return fallbackSession{}, nil
+}
+
+type fallbackSession struct{}
+
+func (fallbackSession) Apply(*exec.Cmd) error        { return nil }
+func (fallbackSession) PeakMemoryKB() (int64, error) { return 0, nil }
+func (fallbackSession) OOMKilled() (bool, error)     { return false, nil }
+func (fallbackSession) Close() error                 { return nil }

--- a/src/cgroup/cgroup_linux.go
+++ b/src/cgroup/cgroup_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package cgroup
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// Apply는 clone3(CLONE_INTO_CGROUP)로 프로세스가 태어나는 순간부터 세션 cgroup에
+// 속하게 한다. 시작 후 cgroup.procs에 PID를 쓰는 방식은 초기 할당 메모리가
+// 누락되는 레이스가 있어 쓰지 않는다.
+func (s *fsSession) Apply(cmd *exec.Cmd) error {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.UseCgroupFD = true
+	cmd.SysProcAttr.CgroupFD = int(s.fd.Fd())
+	return nil
+}

--- a/src/cgroup/cgroup_other.go
+++ b/src/cgroup/cgroup_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package cgroup
+
+import "os/exec"
+
+// Apply는 non-Linux에서 no-op이다. macOS에서는 컴파일(IDE/gopls) 호환만 보장하며,
+// 서버 실행과 테스트는 전부 Docker(Linux)에서 수행한다.
+func (s *fsSession) Apply(cmd *exec.Cmd) error {
+	return nil
+}

--- a/src/cgroup/cgroup_test.go
+++ b/src/cgroup/cgroup_test.go
@@ -1,0 +1,285 @@
+package cgroup
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// fakeRoot는 t.TempDir()에 가짜 cgroupfs 루트를 만들고, /proc/self/cgroup 내용을
+// 주입해 환경을 흉내 낸다. 기본은 host cgroupns(k8s privileged) 상황이며,
+// fakeSelfCgroup으로 로컬 Docker(private cgroupns, "0::/") 상황을 만들 수 있다.
+func fakeRoot(t *testing.T, controllers string, procsPIDs []string) string {
+	t.Helper()
+	fakeSelfCgroup(t, "0::/kubepods.slice/kubepods-pod.slice/crio-abc.scope\n")
+	root := t.TempDir()
+	writeFakeFile(t, filepath.Join(root, "cgroup.controllers"), controllers)
+	writeFakeFile(t, filepath.Join(root, "cgroup.procs"), strings.Join(procsPIDs, "\n"))
+	return root
+}
+
+func fakeSelfCgroup(t *testing.T, content string) {
+	t.Helper()
+	original := readSelfCgroup
+	readSelfCgroup = func() ([]byte, error) { return []byte(content), nil }
+	t.Cleanup(func() { readSelfCgroup = original })
+}
+
+func writeFakeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFakeFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func podDirOf(t *testing.T, root string) string {
+	t.Helper()
+	pod, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(root, baseDirName, pod)
+}
+
+func TestParsePeakKB(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		want    int64
+		wantErr bool
+	}{
+		{name: "정상 값(바이트)을 KB로 변환한다", data: "39324672\n", want: 38403},
+		{name: "1024 미만은 0KB", data: "1000", want: 0},
+		{name: "0", data: "0\n", want: 0},
+		{name: "숫자가 아니면 에러", data: "max\n", wantErr: true},
+		{name: "빈 파일이면 에러", data: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePeakKB([]byte(tt.data))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseOOMKilled(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "oom_kill > 0이면 true",
+			data: "low 0\nhigh 0\nmax 12\noom 3\noom_kill 1\noom_group_kill 0\n",
+			want: true,
+		},
+		{
+			name: "oom_kill == 0이면 false (oom 카운트만 있으면 kill 아님)",
+			data: "low 0\nhigh 0\nmax 0\noom 3\noom_kill 0\n",
+			want: false,
+		},
+		{name: "oom_kill 라인이 없으면 false", data: "low 0\nhigh 0\n", want: false},
+		{name: "빈 파일이면 false", data: "", want: false},
+		{name: "oom_kill 값이 숫자가 아니면 에러", data: "oom_kill abc\n", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseOOMKilled([]byte(tt.data))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetupAt(t *testing.T) {
+	self := strconv.Itoa(os.Getpid())
+
+	t.Run("memory 컨트롤러가 없으면 폴백", func(t *testing.T) {
+		root := fakeRoot(t, "cpuset cpu io", nil)
+		monitor, err := SetupAt(root)
+		if err == nil {
+			t.Fatal("에러를 기대했지만 nil")
+		}
+		if _, ok := monitor.(fallbackMonitor); !ok {
+			t.Errorf("폴백 Monitor를 기대했지만 %T", monitor)
+		}
+	})
+
+	t.Run("cgroupfs가 없으면 폴백 (macOS 등)", func(t *testing.T) {
+		monitor, err := SetupAt(filepath.Join(t.TempDir(), "no-such-dir"))
+		if err == nil {
+			t.Fatal("에러를 기대했지만 nil")
+		}
+		if _, ok := monitor.(fallbackMonitor); !ok {
+			t.Errorf("폴백 Monitor를 기대했지만 %T", monitor)
+		}
+	})
+
+	t.Run("host cgroupns(k8s): 프로세스 이동 없이 파드 계층만 생성", func(t *testing.T) {
+		root := fakeRoot(t, "cpuset cpu io memory", []string{"1", "42"})
+		monitor, err := SetupAt(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := monitor.(*fsMonitor); !ok {
+			t.Fatalf("fsMonitor를 기대했지만 %T", monitor)
+		}
+		if _, err := os.Stat(podDirOf(t, root)); err != nil {
+			t.Errorf("파드 계층 디렉터리가 없음: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(root, leafName)); err == nil {
+			t.Error("host cgroupns에서는 leaf cgroup을 만들면 안 됨")
+		}
+		got := readFakeFile(t, filepath.Join(root, baseDirName, "cgroup.subtree_control"))
+		if got != "+memory" {
+			t.Errorf("base subtree_control = %q, want %q", got, "+memory")
+		}
+		got = readFakeFile(t, filepath.Join(podDirOf(t, root), "cgroup.subtree_control"))
+		if got != "+memory" {
+			t.Errorf("pod subtree_control = %q, want %q", got, "+memory")
+		}
+	})
+
+	t.Run("private cgroupns(로컬 Docker): 루트 프로세스를 leaf로 옮기고 위임", func(t *testing.T) {
+		root := fakeRoot(t, "memory pids", []string{self, "99"})
+		fakeSelfCgroup(t, "0::/\n")
+		if _, err := SetupAt(root); err != nil {
+			t.Fatal(err)
+		}
+		// 가짜 파일시스템에서는 매 쓰기가 덮어쓰므로 마지막 쓰기(자기 PID)가 남는다.
+		// 실제 cgroupfs는 쓰기마다 프로세스가 이동한다. 여기서는 쓰기 시도 여부만 검증.
+		leafProcs := readFakeFile(t, filepath.Join(root, leafName, "cgroup.procs"))
+		if leafProcs != self {
+			t.Errorf("leaf cgroup.procs = %q, want %q (자기 PID가 반드시 이동돼야 함)", leafProcs, self)
+		}
+		got := readFakeFile(t, filepath.Join(root, "cgroup.subtree_control"))
+		if got != "+memory" {
+			t.Errorf("root subtree_control = %q, want %q", got, "+memory")
+		}
+	})
+
+	t.Run("시작 시 자기 파드의 잔존 세션만 정리한다", func(t *testing.T) {
+		root := fakeRoot(t, "memory", nil)
+		stale := filepath.Join(podDirOf(t, root), "stale-session")
+		otherPod := filepath.Join(root, baseDirName, "other-pod", "active-session")
+		for _, dir := range []string{stale, otherPod} {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := SetupAt(root); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(stale); err == nil {
+			t.Error("자기 파드의 잔존 세션이 정리되지 않음")
+		}
+		if _, err := os.Stat(otherPod); err != nil {
+			t.Error("다른 파드의 세션을 삭제함 — 절대 건드리면 안 됨")
+		}
+	})
+}
+
+func TestNewSession(t *testing.T) {
+	newMonitor := func(t *testing.T) (*fsMonitor, string) {
+		root := fakeRoot(t, "memory", nil)
+		monitor, err := SetupAt(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return monitor.(*fsMonitor), root
+	}
+
+	t.Run("메모리 제한이 있으면 안전망 상한과 스왑 금지를 기록한다", func(t *testing.T) {
+		monitor, root := newMonitor(t)
+		session, err := monitor.NewSession("1", 65536) // 64MB
+		if err != nil {
+			t.Fatal(err)
+		}
+		dir := filepath.Join(podDirOf(t, root), "1")
+		wantMax := strconv.FormatInt(int64(65536)*1024+safetyMarginBytes, 10)
+		if got := readFakeFile(t, filepath.Join(dir, "memory.max")); got != wantMax {
+			t.Errorf("memory.max = %q, want %q", got, wantMax)
+		}
+		if got := readFakeFile(t, filepath.Join(dir, "memory.swap.max")); got != "0" {
+			t.Errorf("memory.swap.max = %q, want %q", got, "0")
+		}
+		// 가짜 파일시스템에서는 memory.max 등 일반 파일이 남아 rmdir이 실패하므로
+		// Close의 삭제 성공 여부는 제한 없는 세션 테스트에서 검증한다.
+		_ = session
+	})
+
+	t.Run("메모리 제한이 없으면 제한 파일을 만들지 않고, Close가 cgroup을 삭제한다", func(t *testing.T) {
+		monitor, root := newMonitor(t)
+		session, err := monitor.NewSession("2", 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dir := filepath.Join(podDirOf(t, root), "2")
+		if _, err := os.Stat(filepath.Join(dir, "memory.max")); err == nil {
+			t.Error("제한이 없는데 memory.max가 생성됨")
+		}
+		if err := session.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(dir); err == nil {
+			t.Error("Close 후에도 세션 cgroup이 남아 있음")
+		}
+	})
+
+	t.Run("PeakMemoryKB와 OOMKilled는 세션 cgroup의 파일을 읽는다", func(t *testing.T) {
+		monitor, root := newMonitor(t)
+		session, err := monitor.NewSession("3", 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dir := filepath.Join(podDirOf(t, root), "3")
+		writeFakeFile(t, filepath.Join(dir, "memory.peak"), "583168\n") // 569KB
+		writeFakeFile(t, filepath.Join(dir, "memory.events"), "oom 1\noom_kill 1\n")
+
+		peak, err := session.PeakMemoryKB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if peak != 569 {
+			t.Errorf("peak = %d, want 569", peak)
+		}
+		oom, err := session.OOMKilled()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !oom {
+			t.Error("OOMKilled = false, want true")
+		}
+	})
+
+	t.Run("같은 이름의 세션은 중복 생성할 수 없다", func(t *testing.T) {
+		monitor, _ := newMonitor(t)
+		if _, err := monitor.NewSession("dup", 0); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := monitor.NewSession("dup", 0); err == nil {
+			t.Error("중복 세션 생성이 성공하면 안 됨")
+		}
+	})
+}

--- a/src/executor/executor.go
+++ b/src/executor/executor.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
+	"sync/atomic"
 	"time"
 
+	"leita/src/cgroup"
 	"leita/src/entity"
 
 	"github.com/gofiber/fiber/v3/log"
@@ -16,14 +19,20 @@ import (
 
 type Executor interface {
 	Build(buildCmd []string) (entity.JudgeResultEnum, error)
-	Run(runCmd []string, input []byte, timeLimit int) (entity.JudgeResultEnum, []byte, int64, int64, error)
+	Run(runCmd []string, input []byte, timeLimit, memoryLimit int) (entity.JudgeResultEnum, []byte, int64, int64, error)
 	Delete(deleteCmd []string) error
 }
 
-type OsExecutor struct{}
+type OsExecutor struct {
+	monitor cgroup.Monitor
+	seq     atomic.Int64
+}
 
-func NewOsExecutor() *OsExecutor {
-	return &OsExecutor{}
+func NewOsExecutor(monitor cgroup.Monitor) *OsExecutor {
+	if monitor == nil {
+		monitor = cgroup.NewFallbackMonitor()
+	}
+	return &OsExecutor{monitor: monitor}
 }
 
 func (e *OsExecutor) Build(buildCmd []string) (entity.JudgeResultEnum, error) {
@@ -50,8 +59,21 @@ func (e *OsExecutor) Build(buildCmd []string) (entity.JudgeResultEnum, error) {
 	return entity.JudgeCorrect, nil
 }
 
-func (e *OsExecutor) Run(runCmd []string, input []byte, timeLimit int) (entity.JudgeResultEnum, []byte, int64, int64, error) {
+func (e *OsExecutor) Run(runCmd []string, input []byte, timeLimit, memoryLimit int) (entity.JudgeResultEnum, []byte, int64, int64, error) {
 	log.Info("프로그램 실행 중...")
+
+	// 세션 이름은 파드 내 원자 카운터로 유일성을 보장한다.
+	// (파드 간 유일성은 cgroup 경로의 파드 계층이 담당)
+	session, err := e.monitor.NewSession(strconv.FormatInt(e.seq.Add(1), 10), memoryLimit)
+	if err != nil {
+		log.Warn("cgroup 세션 생성 실패, 메모리 측정 없이 실행: ", err)
+		session = cgroup.NewFallbackSession()
+	}
+	defer func() {
+		if err := session.Close(); err != nil {
+			log.Warn(err)
+		}
+	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeLimit)*time.Millisecond)
 	defer cancel()
@@ -64,30 +86,52 @@ func (e *OsExecutor) Run(runCmd []string, input []byte, timeLimit int) (entity.J
 	cmd.Stdout = &outputBuffer
 	cmd.Stderr = &stderr
 
+	if err := session.Apply(cmd); err != nil {
+		log.Warn("cgroup 세션 적용 실패, 메모리 측정 없이 실행: ", err)
+	}
+
 	if err := cmd.Start(); err != nil {
 		log.Error(err)
 		return entity.JudgeRuntimeError, nil, 0, 0, err
 	}
 
 	startTime := time.Now()
-	err := cmd.Wait()
+	err = cmd.Wait()
 	usedTime := time.Since(startTime).Milliseconds()
+
+	usedMemory, memErr := session.PeakMemoryKB()
+	if memErr != nil {
+		log.Warn(memErr)
+	}
+
+	// 판정 우선순위: OOM → 타임아웃 → 런타임 에러.
+	// OOM kill은 SIGKILL이라 그대로 두면 RUNTIME_ERROR로, 스래싱으로 느려진
+	// 경우에는 TIME_OUT으로 오분류되므로 반드시 먼저 확인한다.
+	oomKilled, oomErr := session.OOMKilled()
+	if oomErr != nil {
+		log.Warn(oomErr)
+	}
+	if oomKilled {
+		memoryOutError := fmt.Errorf("메모리 제한 초과 (사용: %dKB)", usedMemory)
+		log.Error(memoryOutError)
+		return entity.JudgeMemoryOut, nil, usedTime, usedMemory, memoryOutError
+	}
 
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		log.Error(ctx.Err().Error())
-		return entity.JudgeTimeOut, nil, 0, 0, ctx.Err()
+		return entity.JudgeTimeOut, nil, usedTime, usedMemory, ctx.Err()
 	}
 
 	if err != nil {
 		runtimeError := fmt.Errorf("\n%w\n%s", err, stderr.String())
 		log.Error(runtimeError)
-		return entity.JudgeRuntimeError, nil, 0, 0, runtimeError
+		return entity.JudgeRuntimeError, nil, usedTime, usedMemory, runtimeError
 	}
 
 	output := outputBuffer.Bytes()
 	output = bytes.TrimRight(output, "\n\r\t ")
 
-	return entity.JudgeCorrect, output, usedTime, 0, nil
+	return entity.JudgeCorrect, output, usedTime, usedMemory, nil
 }
 
 func (e *OsExecutor) Delete(deleteCmd []string) error {

--- a/src/executor/integration_linux_test.go
+++ b/src/executor/integration_linux_test.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package executor
+
+import (
+	"testing"
+
+	"leita/src/cgroup"
+	"leita/src/entity"
+)
+
+// TestRunMeasuresMemory는 실제 cgroupfs가 쓰기 가능한 환경(--privileged 컨테이너)
+// 에서만 동작하는 통합 테스트다. 그 외 환경에서는 skip된다.
+// 계획서 Phase 5의 검증 기준: dd가 30MB 버퍼를 할당하므로 측정값이 그 근처여야 한다.
+func TestRunMeasuresMemory(t *testing.T) {
+	monitor, err := cgroup.Setup()
+	if err != nil {
+		t.Skipf("cgroup을 쓸 수 없는 환경이라 skip: %v", err)
+	}
+
+	exec := NewOsExecutor(monitor)
+	result, _, usedTime, usedMemory, err := exec.Run(
+		[]string{"dd", "if=/dev/zero", "of=/dev/null", "bs=30M", "count=1"},
+		nil,
+		5000,
+		262144, // 256MB
+	)
+	if err != nil {
+		t.Fatalf("Run 실패: %v", err)
+	}
+	if result != entity.JudgeCorrect {
+		t.Errorf("result = %v, want CORRECT", result)
+	}
+	if usedTime <= 0 {
+		t.Errorf("usedTime = %d, 0보다 커야 함", usedTime)
+	}
+	// dd 버퍼 30MB(30720KB) + 고정비. 측정이 동작하면 30MB 이상,
+	// 상한은 여유 있게 3배로 잡는다.
+	if usedMemory < 30720 || usedMemory > 92160 {
+		t.Errorf("usedMemory = %dKB, want 30720~92160KB (30MB 버퍼 + 고정비)", usedMemory)
+	}
+}

--- a/src/service/problem/service.go
+++ b/src/service/problem/service.go
@@ -89,7 +89,7 @@ func (service *Service) SubmitProblem(dto entity.SubmitProblemDTO) (entity.Judge
 	result, usedTime, usedMemory, err := service.judgeSubmit(runCmd, submitId, timeLimit, memoryLimit)
 	if err != nil {
 		log.Error(err)
-		return result, 0, 0, err
+		return result, usedTime, usedMemory, err
 	}
 
 	return result, usedTime, usedMemory, nil
@@ -188,10 +188,10 @@ func (service *Service) judgeSubmit(runCmd []string, submitId int, timeLimit, me
 			return entity.JudgeUnknown, 0, 0, err
 		}
 
-		result, executeContents, usedTime, usedMemory, err := service.exec.Run(runCmd, inputContents, timeLimit)
+		result, executeContents, usedTime, usedMemory, err := service.exec.Run(runCmd, inputContents, timeLimit, memoryLimit)
 		if err != nil {
 			log.Error(err)
-			return result, 0, 0, err
+			return result, usedTime, usedMemory, err
 		}
 
 		outputData, err := service.fileRepo.ReadOutput(submitId, i, "submit")
@@ -212,13 +212,8 @@ func (service *Service) judgeSubmit(runCmd []string, submitId int, timeLimit, me
 		usedMemories = append(usedMemories, usedMemory)
 	}
 
-	usedTime := int64(0)
-	if testCaseNum > 1 {
-		usedTime = sumInt64(usedTimes[1:]) / (int64(testCaseNum) - 1)
-	} else if testCaseNum == 1 {
-		usedTime = usedTimes[0]
-	}
-	usedMemory := sumInt64(usedMemories) / int64(testCaseNum)
+	usedTime := averageExcludingWarmup(usedTimes)
+	usedMemory := averageExcludingWarmup(usedMemories)
 
 	if !allTrue(judgeResults) {
 		printJudgeSubmitResult(false, usedTime, usedMemory)
@@ -253,7 +248,7 @@ func (service *Service) judgeRun(runCmd []string, submitId int, timeLimit, memor
 			return []entity.RunProblemResult{{Result: entity.JudgeUnknown, Error: err}}
 		}
 
-		result, executeContents, usedTime, usedMemory, err := service.exec.Run(runCmd, inputContents, timeLimit)
+		result, executeContents, usedTime, usedMemory, err := service.exec.Run(runCmd, inputContents, timeLimit, memoryLimit)
 		if err != nil {
 			log.Error(err)
 			return []entity.RunProblemResult{{Result: result, Error: err}}
@@ -315,6 +310,18 @@ func sumInt64(s []int64) int64 {
 		sum += v
 	}
 	return sum
+}
+
+// averageExcludingWarmup은 첫 번째 테스트케이스(워밍업)를 제외한 평균을 구한다.
+// 시간은 JIT/캐시 예열, 메모리는 페이지 캐시 첫 적재 비용이 첫 케이스에 몰리기 때문이다.
+func averageExcludingWarmup(s []int64) int64 {
+	if len(s) > 1 {
+		return sumInt64(s[1:]) / int64(len(s)-1)
+	}
+	if len(s) == 1 {
+		return s[0]
+	}
+	return 0
 }
 
 func printSubmitProblemInfo(lang string, submitId int, problemId string, code []byte, timeLimit, memoryLimit int) {

--- a/src/service/problem/service_test.go
+++ b/src/service/problem/service_test.go
@@ -35,7 +35,7 @@ func (f *fakeExecutor) Build(buildCmd []string) (entity.JudgeResultEnum, error) 
 	return f.buildResult, f.buildErr
 }
 
-func (f *fakeExecutor) Run(runCmd []string, input []byte, timeLimit int) (entity.JudgeResultEnum, []byte, int64, int64, error) {
+func (f *fakeExecutor) Run(runCmd []string, input []byte, timeLimit, memoryLimit int) (entity.JudgeResultEnum, []byte, int64, int64, error) {
 	r := f.runResults[f.runCalls]
 	f.runCalls++
 	return r.result, r.output, r.usedTime, r.usedMemory, r.err
@@ -110,40 +110,46 @@ func TestSubmitProblem(t *testing.T) {
 		{
 			name: "정답: 모든 테스트케이스 일치",
 			fileRepo: &fakeFileRepo{
-				testCaseCount: 2,
-				inputs:        [][]byte{[]byte(b64("in0")), []byte(b64("in1"))},
-				outputs:       [][]byte{[]byte(b64("3")), []byte(b64("7"))},
+				testCaseCount: 5,
+				inputs:        [][]byte{[]byte(b64("in0")), []byte(b64("in1")), []byte(b64("in2")), []byte(b64("in3")), []byte(b64("in4"))},
+				outputs:       [][]byte{[]byte(b64("3")), []byte(b64("7")), []byte(b64("11")), []byte(b64("15")), []byte(b64("19"))},
 			},
 			exec: &fakeExecutor{
 				buildResult: entity.JudgeCorrect,
 				runResults: []runResult{
 					{result: entity.JudgeCorrect, output: []byte("3"), usedTime: 100, usedMemory: 1000},
-					{result: entity.JudgeCorrect, output: []byte("7"), usedTime: 300, usedMemory: 3000},
+					{result: entity.JudgeCorrect, output: []byte("7"), usedTime: 200, usedMemory: 2000},
+					{result: entity.JudgeCorrect, output: []byte("11"), usedTime: 300, usedMemory: 3000},
+					{result: entity.JudgeCorrect, output: []byte("15"), usedTime: 400, usedMemory: 4000},
+					{result: entity.JudgeCorrect, output: []byte("19"), usedTime: 500, usedMemory: 5000},
 				},
 			},
 			wantResult:        entity.JudgeCorrect,
-			wantUsedTime:      300, // 워밍업(첫 케이스 100ms) 제외 평균
-			wantUsedMemory:    2000,
+			wantUsedTime:      350,  // 워밍업(첫 케이스 100ms) 제외 평균 (200+300+400+500)/4
+			wantUsedMemory:    3500, // 메모리도 워밍업(첫 케이스 1000KB) 제외 평균
 			wantDeleteCalls:   1,
 			wantSaveCodeCalls: 1,
 		},
 		{
 			name: "오답: 워밍업 케이스만 불일치해도 전체 결과는 WRONG",
 			fileRepo: &fakeFileRepo{
-				testCaseCount: 2,
-				inputs:        [][]byte{[]byte(b64("in0")), []byte(b64("in1"))},
-				outputs:       [][]byte{[]byte(b64("3")), []byte(b64("7"))},
+				testCaseCount: 5,
+				inputs:        [][]byte{[]byte(b64("in0")), []byte(b64("in1")), []byte(b64("in2")), []byte(b64("in3")), []byte(b64("in4"))},
+				outputs:       [][]byte{[]byte(b64("3")), []byte(b64("7")), []byte(b64("11")), []byte(b64("15")), []byte(b64("19"))},
 			},
 			exec: &fakeExecutor{
 				buildResult: entity.JudgeCorrect,
 				runResults: []runResult{
 					{result: entity.JudgeCorrect, output: []byte("WRONG"), usedTime: 100, usedMemory: 1000},
-					{result: entity.JudgeCorrect, output: []byte("7"), usedTime: 300, usedMemory: 3000},
+					{result: entity.JudgeCorrect, output: []byte("7"), usedTime: 200, usedMemory: 2000},
+					{result: entity.JudgeCorrect, output: []byte("11"), usedTime: 300, usedMemory: 3000},
+					{result: entity.JudgeCorrect, output: []byte("15"), usedTime: 400, usedMemory: 4000},
+					{result: entity.JudgeCorrect, output: []byte("19"), usedTime: 500, usedMemory: 5000},
 				},
 			},
 			wantResult:        entity.JudgeWrong,
-			wantUsedTime:      300,
-			wantUsedMemory:    2000,
+			wantUsedTime:      350,
+			wantUsedMemory:    3500,
 			wantDeleteCalls:   1,
 			wantSaveCodeCalls: 1,
 		},
@@ -160,11 +166,11 @@ func TestSubmitProblem(t *testing.T) {
 			wantSaveCodeCalls: 1,
 		},
 		{
-			name: "Run 실패(타임아웃)",
+			name: "Run 실패(타임아웃): 첫 케이스에서 중단",
 			fileRepo: &fakeFileRepo{
-				testCaseCount: 1,
-				inputs:        [][]byte{[]byte(b64("in0"))},
-				outputs:       [][]byte{[]byte(b64("3"))},
+				testCaseCount: 5,
+				inputs:        [][]byte{[]byte(b64("in0")), []byte(b64("in1")), []byte(b64("in2")), []byte(b64("in3")), []byte(b64("in4"))},
+				outputs:       [][]byte{[]byte(b64("3")), []byte(b64("7")), []byte(b64("11")), []byte(b64("15")), []byte(b64("19"))},
 			},
 			exec: &fakeExecutor{
 				buildResult: entity.JudgeCorrect,
@@ -242,22 +248,31 @@ func TestRunProblem(t *testing.T) {
 			testCases: []entity.TestCase{
 				{Input: b64("in0"), Output: b64("3")},
 				{Input: b64("in1"), Output: b64("7")},
+				{Input: b64("in2"), Output: b64("11")},
+				{Input: b64("in3"), Output: b64("15")},
+				{Input: b64("in4"), Output: b64("19")},
 			},
 			fileRepo: &fakeFileRepo{
-				testCaseCount: 2,
-				inputs:        [][]byte{[]byte(b64("in0")), []byte(b64("in1"))},
-				outputs:       [][]byte{[]byte(b64("3")), []byte(b64("7"))},
+				testCaseCount: 5,
+				inputs:        [][]byte{[]byte(b64("in0")), []byte(b64("in1")), []byte(b64("in2")), []byte(b64("in3")), []byte(b64("in4"))},
+				outputs:       [][]byte{[]byte(b64("3")), []byte(b64("7")), []byte(b64("11")), []byte(b64("15")), []byte(b64("19"))},
 			},
 			exec: &fakeExecutor{
 				buildResult: entity.JudgeCorrect,
 				runResults: []runResult{
 					{result: entity.JudgeCorrect, output: []byte("3")},
 					{result: entity.JudgeCorrect, output: []byte("WRONG")},
+					{result: entity.JudgeCorrect, output: []byte("11")},
+					{result: entity.JudgeCorrect, output: []byte("15")},
+					{result: entity.JudgeCorrect, output: []byte("WRONG2")},
 				},
 			},
 			wantResults: []entity.RunProblemResult{
 				{Result: entity.JudgeCorrect, Output: b64("3")},
 				{Result: entity.JudgeWrong, Output: b64("WRONG")},
+				{Result: entity.JudgeCorrect, Output: b64("11")},
+				{Result: entity.JudgeCorrect, Output: b64("15")},
+				{Result: entity.JudgeWrong, Output: b64("WRONG2")},
 			},
 			wantDeleteCalls: 1,
 		},

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"leita/src/cgroup"
 	"leita/src/executor"
 	"leita/src/repository"
 	"leita/src/service/problem"
@@ -19,7 +20,12 @@ func NewService() (*Service, error) {
 		return nil, err
 	}
 
-	exec := executor.NewOsExecutor()
+	monitor, err := cgroup.Setup()
+	if err != nil {
+		log.Warn("cgroup 초기화 실패, 메모리 측정 없이 동작합니다: ", err)
+	}
+
+	exec := executor.NewOsExecutor(monitor)
 	problemService := problem.NewService(repository.ProblemRepository, repository.FileRepository, exec)
 
 	return &Service{


### PR DESCRIPTION
Add per-testcase memory measurement using cgroup v2:
- Add src/cgroup package: Monitor/Session abstraction. Each run creates a disposable cgroup under /sys/fs/cgroup/leita-judge/{pod}/{seq}, starts the judged process inside it via clone3(CLONE_INTO_CGROUP), and reads memory.peak (KB) after exit. Build/Delete commands stay outside the cgroup so compiler memory never pollutes the measurement.
- Setup() detects the environment at startup: in private cgroupns (local Docker) it moves root processes to a leaf to satisfy the "no internal processes" rule; in host cgroupns (k8s privileged pods) it only creates the pod-scoped hierarchy. The pod layer (hostname) isolates multiple judge pods sharing a node, and startup cleanup only touches the pod's own leftover sessions.
- Extend Executor.Run with a memoryLimit parameter, apply a safety cap (limit + 1GiB) via memory.max, and classify verdicts in OOM -> timeout -> runtime error order so OOM kills are reported as MEMORY_OUT instead of RUNTIME_ERROR/TIME_OUT.
- Exclude the first testcase (warm-up) from the submit memory average, matching the existing time average: the first run pays the one-off page cache cost of loading the runtime into the fresh cgroup.
- Fall back to a no-op monitor (usedMemory=0) with a warning when cgroup is unavailable (non-privileged containers, macOS).
- Add unit tests with a fake cgroupfs and a Linux integration test that runs only where cgroupfs is writable (--privileged).
- Document the minimum-5-testcases-per-problem policy in CLAUDE.md and align judging test fixtures with it.

Requires securityContext.privileged: true on judge deployments for /sys/fs/cgroup to be writable. Language-specific memory margins and strict limit enforcement are follow-up work.