### PR TITLE
judge-mq

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/andybalholm/brotli v1.2.2 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
 	github.com/go-openapi/jsonpointer v0.24.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.6 // indirect
@@ -32,6 +33,7 @@ require (
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
+	github.com/redis/go-redis/v9 v9.21.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/sony/gobreaker/v2 v2.4.0 // indirect
@@ -41,6 +43,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.72.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -66,6 +68,8 @@ github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
 github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.21.0 h1:FPBE4hhbAke+TLmcY3WkpbDffJEomdqPn3HYiqAtL9E=
+github.com/redis/go-redis/v9 v9.21.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
@@ -101,6 +105,8 @@ github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3i
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/src/datasource/datasource.go
+++ b/src/datasource/datasource.go
@@ -2,10 +2,12 @@ package datasource
 
 import (
 	"github.com/gofiber/fiber/v3/log"
+	"github.com/redis/go-redis/v9"
 )
 
 type DataSource struct {
 	objectStorage *ObjectStorage
+	redisClient   *redis.Client
 }
 
 func NewDataSource() (*DataSource, error) {
@@ -15,11 +17,22 @@ func NewDataSource() (*DataSource, error) {
 		return nil, err
 	}
 
+	rdb, err := NewRedisClient()
+	if err != nil {
+		log.Errorf("Redis initialization failed: %v", err)
+		return nil, err
+	}
+
 	return &DataSource{
 		objectStorage: os,
+		redisClient:   rdb,
 	}, nil
 }
 
 func (ds *DataSource) GetObjectStorage() *ObjectStorage {
 	return ds.objectStorage
+}
+
+func (ds *DataSource) GetRedisClient() *redis.Client {
+	return ds.redisClient
 }

--- a/src/datasource/redis.go
+++ b/src/datasource/redis.go
@@ -1,0 +1,35 @@
+package datasource
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func NewRedisClient() (*redis.Client, error) {
+	host := os.Getenv("REDIS_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+	port := os.Getenv("REDIS_PORT")
+	if port == "" {
+		port = "6379"
+	}
+	password := os.Getenv("REDIS_PASSWORD")
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     fmt.Sprintf("%s:%s", host, port),
+		Password: password,
+		DB:       0,
+	})
+
+	ctx := context.Background()
+	_, err := rdb.Ping(ctx).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Redis at %s:%s: %w", host, port, err)
+	}
+
+	return rdb, nil
+}

--- a/src/entity/problem.go
+++ b/src/entity/problem.go
@@ -14,6 +14,10 @@ type SubmitProblemResponse struct {
 	UsedMemory int64  `json:"usedMemory"`
 }
 
+type SubmitProblemReceiptResponse struct {
+	Status string `json:"status"`
+}
+
 type SubmitProblemDTO struct {
 	ProblemId string
 	SubmitId  int

--- a/src/handler/problem/handler.go
+++ b/src/handler/problem/handler.go
@@ -8,6 +8,7 @@ import (
 type Service interface {
 	SubmitProblem(dto entity.SubmitProblemDTO) (entity.JudgeResultEnum, int64, int64, error)
 	RunProblem(dto entity.RunProblemDTO) []entity.RunProblemResult
+	PublishJudgeResult(submitId int, result entity.JudgeResultEnum, usedTime, usedMemory int64, errStr string) error
 }
 
 type Handler struct {

--- a/src/handler/problem/submit.go
+++ b/src/handler/problem/submit.go
@@ -9,6 +9,8 @@ import (
 	"github.com/gofiber/fiber/v3/log"
 )
 
+var judgeSemaphore = make(chan struct{}, 4)
+
 // SubmitProblem godoc
 //
 //	@Summary		Submit a problem solution
@@ -50,7 +52,9 @@ func (handler *Handler) SubmitProblem() fiber.Handler {
 
 		// 비동기로 고루틴 실행
 		go func() {
+			judgeSemaphore <- struct{}{}
 			defer func() {
+				<-judgeSemaphore
 				if r := recover(); r != nil {
 					log.Errorf("Panic in SubmitProblem goroutine for submit %d: %v", dto.SubmitId, r)
 					_ = handler.service.PublishJudgeResult(dto.SubmitId, entity.JudgeUnknown, 0, 0, "Server Panic during judging")

--- a/src/handler/problem/submit.go
+++ b/src/handler/problem/submit.go
@@ -18,25 +18,25 @@ import (
 //	@Tags			Problem
 //	@Param			problemId	path		string						true	"Problem ID"
 //	@Param			requestBody	body		entity.SubmitProblemRequest	true	"Solution code and metadata"
-//	@Success		200			{object}	entity.SubmitProblemResponse
-//	@Failure		400			{object}	entity.SubmitProblemResponse
-//	@Failure		500			{object}	entity.SubmitProblemResponse
+//	@Success		200			{object}	entity.SubmitProblemReceiptResponse
+//	@Failure		400			{object}	entity.SubmitProblemReceiptResponse
+//	@Failure		500			{object}	entity.SubmitProblemReceiptResponse
 //	@Router			/problem/submit/{problemId} [post]
 func (handler *Handler) SubmitProblem() fiber.Handler {
 	return func(c fiber.Ctx) error {
 		var req entity.SubmitProblemRequest
 		if err := c.Bind().Body(&req); err != nil {
 			log.Error(err)
-			return c.Status(fiber.StatusBadRequest).JSON(entity.SubmitProblemResponse{
-				Error: err.Error(),
+			return c.Status(fiber.StatusBadRequest).JSON(entity.SubmitProblemReceiptResponse{
+				Status: "FAILED_BINDING",
 			})
 		}
 
 		code, err := base64.StdEncoding.DecodeString(req.Code)
 		if err != nil {
 			log.Error(err)
-			return c.Status(fiber.StatusBadRequest).JSON(entity.SubmitProblemResponse{
-				Error: err.Error(),
+			return c.Status(fiber.StatusBadRequest).JSON(entity.SubmitProblemReceiptResponse{
+				Status: "FAILED_DECODING",
 			})
 		}
 
@@ -48,24 +48,28 @@ func (handler *Handler) SubmitProblem() fiber.Handler {
 			Limit:     req.Limit,
 		}
 
-		result, usedTime, usedMemory, err := handler.service.SubmitProblem(dto)
-		if result == entity.JudgeUnknown {
-			log.Error(err)
-			return c.Status(fiber.StatusInternalServerError).JSON(entity.SubmitProblemResponse{
-				Result: entity.JudgeUnknown.String(),
-				Error:  err.Error(),
-			})
-		}
+		// 비동기로 고루틴 실행
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Errorf("Panic in SubmitProblem goroutine for submit %d: %v", dto.SubmitId, r)
+					_ = handler.service.PublishJudgeResult(dto.SubmitId, entity.JudgeUnknown, 0, 0, "Server Panic during judging")
+				}
+			}()
 
-		errStr := ""
-		if err != nil {
-			errStr = err.Error()
-		}
-		return c.Status(fiber.StatusOK).JSON(entity.SubmitProblemResponse{
-			Result:     result.String(),
-			Error:      errStr,
-			UsedTime:   usedTime,
-			UsedMemory: usedMemory,
+			result, usedTime, usedMemory, err := handler.service.SubmitProblem(dto)
+			errStr := ""
+			if err != nil {
+				errStr = err.Error()
+			}
+			errPublish := handler.service.PublishJudgeResult(dto.SubmitId, result, usedTime, usedMemory, errStr)
+			if errPublish != nil {
+				log.Errorf("Failed to publish result to Redis for submit %d: %v", dto.SubmitId, errPublish)
+			}
+		}()
+
+		return c.Status(fiber.StatusOK).JSON(entity.SubmitProblemReceiptResponse{
+			Status: "RECEIVED",
 		})
 	}
 }

--- a/src/repository/repository.go
+++ b/src/repository/repository.go
@@ -6,11 +6,13 @@ import (
 	"leita/src/repository/problem"
 
 	"github.com/gofiber/fiber/v3/log"
+	"github.com/redis/go-redis/v9"
 )
 
 type Repository struct {
 	ProblemRepository *problem.Repository
 	FileRepository    filerepo.Repository
+	RedisClient       *redis.Client
 }
 
 func NewRepository() (*Repository, error) {
@@ -23,5 +25,6 @@ func NewRepository() (*Repository, error) {
 	return &Repository{
 		ProblemRepository: problem.NewRepository(dataSource),
 		FileRepository:    filerepo.NewLocalRepository(),
+		RedisClient:       dataSource.GetRedisClient(),
 	}, nil
 }

--- a/src/service/problem/service.go
+++ b/src/service/problem/service.go
@@ -2,10 +2,12 @@ package problem
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"errors"
 	"math"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -15,6 +17,7 @@ import (
 	filerepo "leita/src/repository/file"
 
 	"github.com/gofiber/fiber/v3/log"
+	"github.com/redis/go-redis/v9"
 )
 
 // storageRepository는 OCI 오브젝트 스토리지 접근을 추상화한다.
@@ -24,20 +27,29 @@ type storageRepository interface {
 }
 
 type Service struct {
-	storage  storageRepository
-	fileRepo filerepo.Repository
-	exec     executor.Executor
+	storage   storageRepository
+	fileRepo  filerepo.Repository
+	exec      executor.Executor
+	redis     *redis.Client
+	streamKey string
 }
 
 func NewService(
 	storage storageRepository,
 	fileRepo filerepo.Repository,
 	exec executor.Executor,
+	redisClient *redis.Client,
 ) *Service {
+	streamKey := os.Getenv("REDIS_STREAM_KEY")
+	if streamKey == "" {
+		streamKey = "judge-result-stream"
+	}
 	return &Service{
-		storage:  storage,
-		fileRepo: fileRepo,
-		exec:     exec,
+		storage:   storage,
+		fileRepo:  fileRepo,
+		exec:      exec,
+		redis:     redisClient,
+		streamKey: streamKey,
 	}
 }
 
@@ -361,4 +373,29 @@ func printJudgeSubmitResult(isCorrect bool, usedTime, usedMemory int64) {
 	}
 	log.Info("평균 사용 시간: ", usedTime, "ms")
 	log.Info("평균 사용 메모리: ", usedMemory, "KB")
+}
+
+func (service *Service) PublishJudgeResult(submitId int, result entity.JudgeResultEnum, usedTime, usedMemory int64, errStr string) error {
+	ctx := context.Background()
+
+	values := map[string]interface{}{
+		"submitId":   strconv.Itoa(submitId),
+		"result":     result.String(),
+		"error":      errStr,
+		"usedMemory": strconv.FormatInt(usedMemory, 10),
+		"usedTime":   strconv.FormatInt(usedTime, 10),
+	}
+
+	err := service.redis.XAdd(ctx, &redis.XAddArgs{
+		Stream: service.streamKey,
+		Values: values,
+	}).Err()
+
+	if err != nil {
+		log.Errorf("XAdd error: %v", err)
+		return err
+	}
+
+	log.Infof("Successfully published judge result for submit %d: %s", submitId, result.String())
+	return nil
 }

--- a/src/service/problem/service.go
+++ b/src/service/problem/service.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"leita/src/entity"
 	"leita/src/executor"
@@ -376,7 +377,8 @@ func printJudgeSubmitResult(isCorrect bool, usedTime, usedMemory int64) {
 }
 
 func (service *Service) PublishJudgeResult(submitId int, result entity.JudgeResultEnum, usedTime, usedMemory int64, errStr string) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
 
 	values := map[string]interface{}{
 		"submitId":   strconv.Itoa(submitId),

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -26,7 +26,7 @@ func NewService() (*Service, error) {
 	}
 
 	exec := executor.NewOsExecutor(monitor)
-	problemService := problem.NewService(repository.ProblemRepository, repository.FileRepository, exec)
+	problemService := problem.NewService(repository.ProblemRepository, repository.FileRepository, exec, repository.RedisClient)
 
 	return &Service{
 		ProblemService: problemService,


### PR DESCRIPTION
### As-is
- Step
        1. Client에서 App Server에 요청
        2. App Server에서 Judge request 생성
        3. App Server에서 Judge Server에 요청
        4. App Server는 Judge Server의 Judge 결과 응답이 올 때까지 대기 (현재 10초 → 60초)
        5. Judge Server에서 Judge 진행
        6. 응답이 오면 App Server는 DB 상태 업데이트 후 Client에 응답 전달
- 문제점
        - 10초 이상 걸리는 경우(문제 스펙 상, 내부 큐에 대기하는 시간, 네트워크 이슈 등)에 Timeout 발생
        - App Server의 상태에 따라 채점 결과 유실 가능성이 있음
        
### To-be
- Step
        1. Client에서 App Server에 요청
        2. App Server에서 Judge request 생성
        3. App Server에서 Judge Server에 요청
        4. 성공적으로 채점 요청이 생성되었다는 응답을 App Server에 전달
        5. Judge Server에서 Judge 진행
        6. Judge 완료 후 Redis Stream에 Entry 추가
        7. Entry가 추가되면 App Server는 DB 상태 업데이트 후 Client에 응답 전달 및 XACK 전송